### PR TITLE
Adding node-config.  Adding "prefer-const" rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Specify the `extends` property in the `.eslintrc` file:
 ```json
 {
   "extends": "brightspace",
-  ...
+  // ...
 }
 ```
 
@@ -37,7 +37,7 @@ Specify the desired config for the `extends` property:
 ```json
 {
   "extends": "brightspace/react-config",
-  ...
+  // ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Specify the `extends` property in the `.eslintrc` file:
 
 ```json
 {
-  "extends": "brightspace",
-  // ...
+  "extends": "brightspace"
 }
 ```
 
@@ -36,8 +35,7 @@ Specify the desired config for the `extends` property:
 
 ```json
 {
-  "extends": "brightspace/react-config",
-  // ...
+  "extends": "brightspace/react-config"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,28 @@ Simply specify the `extends` property in the `.eslintrc` file as shown below. **
 
 Specify the `extends` property in the `.eslintrc` file:
 
-```javascript
+```json
 {
   "extends": "brightspace",
   ...
 }
 ```
 
-### React Config
+### Environment Specific Configs
 
-Specify the `react-config` config for the `extends` property: 
+Specify the desired config for the `extends` property: 
 
-```javascript
+* `browser-config` : sets up browser globals
+* `node-config` : sets up node globals including es6 env features
+* `react-config` : sets up env for jsx and es6, including globals for jest
+
+```json
 {
   "extends": "brightspace/react-config",
   ...
 }
 ```
+
 
 The [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) plugin is included witht this configuration, which enables use of the rules it provides.
 

--- a/browser-config.js
+++ b/browser-config.js
@@ -1,0 +1,10 @@
+var baseConfig = require('./index'),
+	extend = require('extend');
+
+var browserConfig = {
+  "env": {
+    "browser": true
+  }
+};
+
+module.exports = extend(true, baseConfig, browserConfig);

--- a/common-config.js
+++ b/common-config.js
@@ -20,6 +20,7 @@ module.exports = {
     "no-undef": 2,
     "no-unreachable": 2,
     "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+    "prefer-const": 2, // nr
     "quotes": [2, "single", "avoid-escape"], // nr
     "semi": 2, // nr
     "space-after-keywords": 2, // nr

--- a/node-config.js
+++ b/node-config.js
@@ -1,0 +1,11 @@
+var baseConfig = require('./index'),
+	extend = require('extend');
+
+var nodeConfig = {
+  "env": {
+    "es6": true,
+    "node": true
+  }
+};
+
+module.exports = extend(true, baseConfig, nodeConfig);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brightspace",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Common Brightspace eslint configs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@omsmith : I thought I would take a few minutes to create this for the [suggested enhancement](https://github.com/Brightspace/eslint-config-brightspace/issues/4).

This change simply utilizes the `es6` environment and `node` environments, and sets up the suggested rule override for `prefer-const`.

The `es6` environment includes all the `ecmaFeatures` except for `modules`, and can be found at the bottom of [this file](https://github.com/eslint/eslint/blob/master/conf/environments.js).  We can list them individually if you want, rather than including all the ones in the `es6` defined environment - it will just require more maintenance.  For the purpose of linting, I'm ok with just utilizing the environment unless it causes problems in dev. 

I've added an override for `prefer-const`.  I am proposing that we include this not just for node because I think that is the preferred practice regardless.  Therefore I am also proposing we bump the minor version since it affects the other configs as well.  If there are other rules you want included, feel free to update ot let me know - the default rules can be found [here](https://github.com/eslint/eslint/blob/master/conf/eslint.json). I think the ES6 specific rules are listed towards the bottom.