### PR TITLE
Move eslint to peer dependencies and allow v3

### DIFF
--- a/common-config.js
+++ b/common-config.js
@@ -2,13 +2,14 @@
 // nr = not as per eslint:recommended
 
 module.exports = {
+  "extends": "eslint:recommended",
   "rules": {
     "comma-spacing": 2, // nr
     "eol-last": 2, // nr
     "eqeqeq": 2, // nr
     "indent": [2, "tab", { "SwitchCase": 1 }], // nr
     "new-parens": 2, // nr
-    "no-debugger": 2, 
+    "no-debugger": 2,
     "no-dupe-args": 2,
     "no-dupe-keys": 2,
     "no-duplicate-case": 2,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-var eslint = require('eslint'),
-	extend = require('extend'),
-	commonConfig = require('./common-config');
+var commonConfig = require('./common-config');
 
-var recommendedConfig = eslint.linter.defaults();
-
-module.exports = extend(true, recommendedConfig, commonConfig);
+module.exports = commonConfig;

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   },
   "homepage": "https://github.com/Brightspace/eslint-config-brightspace",
   "devDependencies": {},
+  "peerDependencies": {
+    "eslint": "^2.3.0 || ^3.0.0"
+  },
   "dependencies": {
-    "eslint": "^2.3.0",
     "extend": "^3.0.0"
   }
 }


### PR DESCRIPTION
[`eslint@3.0.0`](http://eslint.org/blog/2016/07/eslint-v3.0.0-released) and its updates brought several enhancements and bugfixes. It'd be nice to use those!

The reason for the switch to peerDependencies is because this is a plugin for eslint. It should not provide eslint itself, that should be up to the user. Providing its own eslint can cause issues, such as trying to use `eslint@2.3.0` when the user is trying to use `eslint@3.0.0`.

r? @dbatiste 
