### PR TITLE
Adding eslint config for lit elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Specify the `extends` property in the `.eslintrc.json` file:
 Specify the desired config for the `extends` property:
 
 * `browser-config` : sets up browser globals
+* `lit-config` : sets up env for browser globals and lit rules for lit elements
 * `node-config` : sets up node globals including es6 env features
 * `react-config` : sets up env for jsx and es6, including globals for jest
 * `polymer-config` : sets up env for browser globals and polymer web components
@@ -46,6 +47,8 @@ Specify the desired config for the `extends` property:
 To use `react-config`, consumers should install the [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) plugin to enable use of the rules it provides.
 
 To use `polymer-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) plugin to extract and lint JavaScript contained in `.html` web component files.
+
+To use `lit-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) and [eslint-plugin-lit](https://github.com/43081j/eslint-plugin-lit) plugins.
 
 See the [eslint rules](http://eslint.org/docs/rules/) for more details on rule configuration.  See the [eslint shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) for more details on creating configs.
 

--- a/lit-config.js
+++ b/lit-config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  "extends": "./index.js",
+  "parser": "babel-eslint",
+  "env": {
+    "browser": true
+  },
+  "plugins": [
+    "lit", "html"
+  ],
+  "globals": {
+    "D2L": false
+  },
+  "rules": {
+    "strict": 0,
+    "lit/no-duplicate-template-bindings": 2,
+    "lit/no-legacy-template-syntax": 2,
+    "lit/no-template-bind": 2,
+    "lit/no-template-map": 0,
+    "lit/no-useless-template-literals": 2,
+    "lit/attribute-value-entities": 2,
+    "lit/binding-positions": 2,
+    "lit/no-property-change-update": 2,
+    "lit/no-invalid-html": 2,
+    "lit/no-value-attribute": 2
+  }
+};

--- a/lit-config.js
+++ b/lit-config.js
@@ -11,7 +11,7 @@ module.exports = {
     "D2L": false
   },
   "rules": {
-    "strict": 0,
+    "strict": [2, "never"],
     "lit/no-duplicate-template-bindings": 2,
     "lit/no-legacy-template-syntax": 2,
     "lit/no-template-bind": 2,


### PR DESCRIPTION
Enabled all the lit rules with the exception of [no-template-map](https://github.com/43081j/eslint-plugin-lit/blob/master/docs/rules/no-template-map.md).

I also considered enabling the `strict` rule to error/warning since `"use strict";` is redundant inside of modules, but we may still use it in demo pages so I kept this rule consistent with our polymer-3 config.  Tests too, but we'll likely have a different config for tests anyway.

Let me know if you disagree with any of the rules.  There are all listed at the bottom here... https://github.com/43081j/eslint-plugin-lit
