### PR TITLE
initial configuration for class member sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Specify the desired config for the `extends` property:
 
 To use `react-config`, consumers should install the [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) plugin to enable use of the rules it provides.
 
-To use `polymer-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) plugin to extract and lint JavaScript contained in `.html` web component files.
+To use `polymer-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) plugin to extract and lint JavaScript contained in `.html` web component files. [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) plugin is required to ensure consistency in class format
 
-To use `lit-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) and [eslint-plugin-lit](https://github.com/43081j/eslint-plugin-lit) plugins.
+To use `lit-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html), [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members), and [eslint-plugin-lit](https://github.com/43081j/eslint-plugin-lit) plugins.
 
 See the [eslint rules](http://eslint.org/docs/rules/) for more details on rule configuration.  See the [eslint shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) for more details on creating configs.
 

--- a/lit-config.js
+++ b/lit-config.js
@@ -1,3 +1,5 @@
+const { sortMemberRules } = require('./sort-member-config');
+
 module.exports = {
   "extends": "./index.js",
   "parser": "babel-eslint",
@@ -33,6 +35,7 @@ module.exports = {
     "lit/binding-positions": 2,
     "lit/no-property-change-update": 2,
     "lit/no-invalid-html": 2,
-    "lit/no-value-attribute": 2
+	"lit/no-value-attribute": 2,
+	...sortMemberRules
   }
 };

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "url": "https://github.com/Brightspace/eslint-config-brightspace/issues"
   },
   "homepage": "https://github.com/Brightspace/eslint-config-brightspace",
-  "peerDependencies": {
-    "eslint-plugin-sort-class-members": "^1.4.0"
-  },
   "devDependencies": {
     "eslint": "^5.16.0"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Brightspace/eslint-config-brightspace/issues"
   },
   "homepage": "https://github.com/Brightspace/eslint-config-brightspace",
-  "devDependencies": {
-    "eslint": "^5.16.0"
+  "dependencies": {
+    "eslint": "^5.15.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brightspace",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Common Brightspace eslint configs.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "url": "https://github.com/Brightspace/eslint-config-brightspace/issues"
   },
   "homepage": "https://github.com/Brightspace/eslint-config-brightspace",
-  "dependencies": {
-    "eslint": "^5.15.1"
+  "peerDependencies": {
+    "eslint-plugin-sort-class-members": "^1.4.0"
+  },
+  "devDependencies": {
+    "eslint": "^5.16.0"
   }
 }

--- a/polymer-3-config.js
+++ b/polymer-3-config.js
@@ -1,3 +1,5 @@
+const { sortMemberRules } = require('./sort-member-config');
+
 module.exports = {
   "extends": "./index.js",
   "parser": "babel-eslint",
@@ -14,17 +16,6 @@ module.exports = {
   },
   "rules": {
 	"strict": 0,
-	"sort-class-members/sort-class-members": [2, {
-		"order": [
-		  "[static-properties]",
-		  "[static-methods]",
-		  "[properties]",
-		  "constructor",
-		  "[methods]",
-		  "[conventional-private-properties]",
-		  "[conventional-private-methods]",
-		],
-		"accessorPairPositioning": "getThenSet",
-	  }]
+	...sortMemberRules
   }
 };

--- a/polymer-3-config.js
+++ b/polymer-3-config.js
@@ -5,13 +5,26 @@ module.exports = {
     "browser": true
   },
   "plugins": [
-    "html"
+	"html",
+	"sort-class-members"
   ],
   "globals": {
     "D2L": false,
     "Polymer": false
   },
   "rules": {
-    "strict": 0
+	"strict": 0,
+	"sort-class-members/sort-class-members": [2, {
+		"order": [
+		  "[static-properties]",
+		  "[static-methods]",
+		  "[properties]",
+		  "constructor",
+		  "[methods]",
+		  "[conventional-private-properties]",
+		  "[conventional-private-methods]",
+		],
+		"accessorPairPositioning": "getThenSet",
+	  }]
   }
 };

--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -8,7 +8,6 @@ module.exports.sortMemberRules = {
 		  "[methods]",
 		  "[conventional-private-properties]",
 		  "[conventional-private-methods]",
-
 		],
 		"groups": {
 			"static-methods": [{ "type": "method", "sort": "alphabetical", "static": true }],

--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -1,0 +1,23 @@
+module.exports.sortMemberRules = {
+	"sort-class-members/sort-class-members": [2, {
+		"order": [
+		  "[static-properties]",
+		  "[static-methods]",
+		  "[properties]",
+		  "constructor",
+		  "[methods]",
+		  "[conventional-private-properties]",
+		  "[conventional-private-methods]",
+
+		],
+		"groups": {
+			"static-methods": [{ "type": "method", "sort": "alphabetical", "static": true }],
+			"static-properties": [{ "type": "property", "sort": "alphabetical", "static": true }],
+			"methods": [{ "type": "method", "sort": "alphabetical"}],
+			"properties": [{ "type": "property", "sort": "alphabetical"}],
+			"conventional-private-methods": [{ "type": "method", "sort": "alphabetical"}],
+			"conventional-private-properties": [{ "type": "property", "sort": "alphabetical"}],
+		},
+		"accessorPairPositioning": "getThenSet",
+	}]
+}


### PR DESCRIPTION
This PR was inspired from a comment @m6jones left on my [pr](https://github.com/BrightspaceHypermediaComponents/organizations/pull/76#discussion_r291747845).  I personally find that comments like that end up not being followed consistently unless you codify the rules somewhere.  So hopefully this works for both of you.

Currently this is configured for just one config, but if we're ok with introducing this plugin we can certainly expand it to the other configs.

As an example this was run against BrightspaceHypermediaComponents/organizations and I got the following output:

```
> eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html


C:\d2l\github\organizations\components\d2l-organization-date\d2l-organization-date.js
  26:2  error  Expected static getter template to come before constructor    sort-class-members/sort-class-members
  32:2  error  Expected static getter properties to come before constructor  sort-class-members/sort-class-members
  50:2  error  Expected static getter observers to come before constructor   sort-class-members/sort-class-members
  58:2  error  Expected static getter is to come before constructor          sort-class-members/sort-class-members

C:\d2l\github\organizations\components\d2l-organization-detail-card\d2l-organization-detail-card.js
   27:2  error  Expected static getter template to come before constructor    sort-class-members/sort-class-members
  323:2  error  Expected static getter properties to come before constructor  sort-class-members/sort-class-members
  358:2  error  Expected static getter observers to come before constructor   sort-class-members/sort-class-members

C:\d2l\github\organizations\components\d2l-organization-image\d2l-organization-image.js
  17:2  error  Expected static getter template to come before constructor    sort-class-members/sort-class-members
  23:2  error  Expected static getter properties to come before constructor  sort-class-members/sort-class-members
  50:2  error  Expected static getter observers to come before constructor   sort-class-members/sort-class-members

C:\d2l\github\organizations\components\d2l-organization-info\d2l-organization-info.js
  27:2  error  Expected static getter template to come before constructor    sort-class-members/sort-class-members
  52:2  error  Expected static getter properties to come before constructor  sort-class-members/sort-class-members
  69:2  error  Expected static getter observers to come before constructor   sort-class-members/sort-class-members
  77:2  error  Expected static getter is to come before constructor          sort-class-members/sort-class-members

C:\d2l\github\organizations\components\d2l-organization-name\d2l-organization-name.js
  26:2  error  Expected static getter template to come before constructor    sort-class-members/sort-class-members
  31:2  error  Expected static getter properties to come before constructor  sort-class-members/sort-class-members
  37:2  error  Expected static getter observers to come before constructor   sort-class-members/sort-class-members
  44:2  error  Expected static getter is to come before constructor          sort-class-members/sort-class-members

C:\d2l\github\organizations\components\d2l-organization-updates\d2l-organization-updates.js
   32:2  error  Expected static getter template to come before constructor    sort-class-members/sort-class-members
  143:2  error  Expected static getter properties to come before constructor  sort-class-members/sort-class-members
  181:2  error  Expected static getter observers to come before constructor   sort-class-members/sort-class-members
  188:2  error  Expected static getter is to come before constructor          sort-class-members/sort-class-members

✖ 22 problems (22 errors, 0 warnings)
```