### PR TITLE
preventing optional catch binding

### DIFF
--- a/lit-config.js
+++ b/lit-config.js
@@ -20,6 +20,7 @@ module.exports = {
 		"arrow-spacing": 2,
 		"no-confusing-arrow": 2,
 		"no-duplicate-imports": 2,
+		"no-restricted-syntax": ["error", "CatchClause[param=null]"],
 		"no-useless-constructor": 2,
 		"no-var": 2,
 		"prefer-arrow-callback": 2,


### PR DESCRIPTION
This prevents:

```javascript
try {
    // something
} catch {
   // sometning
}
```

Empty catch binding [isn't actually a thing yet](https://github.com/tc39/proposal-optional-catch-binding), and the version of Babel used by `polymer build` isn't configured to handle it, so using it causes build failures that look like this:

```
{ err:
   “This experimental syntax requires enabling the parser plugin: ‘optionalCatchBinding’ (211:9)”
}
```