### PR TITLE
Dbatiste/update sort memeber rules

### DIFF
--- a/browser-config.js
+++ b/browser-config.js
@@ -1,4 +1,4 @@
-const { sortMemberRules } = require('./sort-member-config');
+const { getSortMemberRules } = require('./sort-member-config');
 
 module.exports = {
 	"extends": "./index.js",
@@ -16,6 +16,6 @@ module.exports = {
 	},
 	"rules": {
 		"no-console": ["error", { "allow": ["warn", "error"] }],
-		...sortMemberRules
+		...getSortMemberRules()
 	}
 };

--- a/browser-config.js
+++ b/browser-config.js
@@ -15,7 +15,7 @@ module.exports = {
 		"Promise": false
 	},
 	"rules": {
-    "no-console": ["error", { "allow": ["warn", "error"] }],
+		"no-console": ["error", { "allow": ["warn", "error"] }],
 		...sortMemberRules
 	}
 };

--- a/common-config.js
+++ b/common-config.js
@@ -25,8 +25,8 @@ module.exports = {
     "semi": 2, // nr
     "keyword-spacing": 2,
     "space-before-blocks": [2, "always"], // nr
-	"space-before-function-paren": [2, "never"], //nr
-	"space-in-parens": [2, "never"],
+    "space-before-function-paren": [2, "never"], //nr
+    "space-in-parens": [2, "never"],
     "space-infix-ops": 2, // nr
     "strict": [2, "global"], // nr
     "valid-typeof": 2

--- a/lit-config.js
+++ b/lit-config.js
@@ -1,4 +1,4 @@
-const { sortMemberRules } = require('./sort-member-config');
+const { sortMemberGroups } = require('./sort-member-config');
 
 const litSortMemberRules = {
 	"sort-class-members/sort-class-members": [2, {
@@ -11,10 +11,11 @@ const litSortMemberRules = {
 			"[accessor-pairs]",
 			"[lit-methods]",
 			"[methods]",
-			"[conventional-private-properties]",
-			"[conventional-private-methods]"
+			"[private-accessor-pairs]",
+			"[private-properties]",
+			"[private-methods]"
 		],
-		"groups": { ...sortMemberRules.groups,
+		"groups": { ...sortMemberGroups,
 			"lit-methods": [
 				{ "name": "attributeChangedCallback", "type": "method" },
 				{ "name": "connectedCallback", "type": "method" },

--- a/lit-config.js
+++ b/lit-config.js
@@ -1,40 +1,34 @@
-const { sortMemberGroups } = require('./sort-member-config');
+const { getSortMemberRules } = require('./sort-member-config');
 
-const litSortMemberRules = {
-	"sort-class-members/sort-class-members": [2, {
-		"order": [
-			"[lit-static-properties]",
-			"[static-properties]",
-			"[static-methods]",
-			"[properties]",
-			"constructor",
-			"[accessor-pairs]",
-			"[lit-methods]",
-			"[methods]",
-			"[private-accessor-pairs]",
-			"[private-properties]",
-			"[private-methods]"
-		],
-		"groups": { ...sortMemberGroups,
-			"lit-methods": [
-				{ "name": "attributeChangedCallback", "type": "method" },
-				{ "name": "connectedCallback", "type": "method" },
-				{ "name": "disconnectedCallback", "type": "method" },
-				{ "name": "firstUpdated", "type": "method" },
-				{ "name": "performUpdate", "type": "method" },
-				{ "name": "render", "type": "method" },
-				{ "name": "shouldUpdate", "type": "method" },
-				{ "name": "update", "type": "method" },
-				{ "name": "updated", "type": "method" }
-			],
-			"lit-static-properties": [
-				{ "name": "properties", "static": true },
-				{ "name": "styles", "static": true }
-			]
-		},
-		"accessorPairPositioning": "getThenSet"
-	}]
-};
+const sortMemberRules = getSortMemberRules([
+	"[lit-static-properties]",
+	"[static-properties]",
+	"[static-methods]",
+	"[properties]",
+	"constructor",
+	"[accessor-pairs]",
+	"[lit-methods]",
+	"[methods]",
+	"[private-accessor-pairs]",
+	"[private-properties]",
+	"[private-methods]"
+], {
+	"lit-methods": [
+		{ "name": "attributeChangedCallback", "type": "method" },
+		{ "name": "connectedCallback", "type": "method" },
+		{ "name": "disconnectedCallback", "type": "method" },
+		{ "name": "firstUpdated", "type": "method" },
+		{ "name": "performUpdate", "type": "method" },
+		{ "name": "render", "type": "method" },
+		{ "name": "shouldUpdate", "type": "method" },
+		{ "name": "update", "type": "method" },
+		{ "name": "updated", "type": "method" }
+	],
+	"lit-static-properties": [
+		{ "name": "properties", "static": true },
+		{ "name": "styles", "static": true }
+	]
+});
 
 module.exports = {
 	"extends": "./browser-config.js",
@@ -71,6 +65,6 @@ module.exports = {
 		"lit/no-template-map": 0,
 		"lit/no-useless-template-literals": 2,
 		"lit/no-value-attribute": 2,
-		...litSortMemberRules
+		...sortMemberRules
 	}
 };

--- a/lit-config.js
+++ b/lit-config.js
@@ -1,10 +1,48 @@
+const { sortMemberRules } = require('./sort-member-config');
+
+const litSortMemberRules = {
+	"sort-class-members/sort-class-members": [2, {
+		"order": [
+			"[lit-static-properties]",
+			"[static-properties]",
+			"[static-methods]",
+			"[properties]",
+			"constructor",
+			"[accessor-pairs]",
+			"[lit-methods]",
+			"[methods]",
+			"[conventional-private-properties]",
+			"[conventional-private-methods]"
+		],
+		"groups": { ...sortMemberRules.groups,
+			"lit-methods": [
+				{ "name": "attributeChangedCallback", "type": "method" },
+				{ "name": "connectedCallback", "type": "method" },
+				{ "name": "disconnectedCallback", "type": "method" },
+				{ "name": "firstUpdated", "type": "method" },
+				{ "name": "performUpdate", "type": "method" },
+				{ "name": "render", "type": "method" },
+				{ "name": "shouldUpdate", "type": "method" },
+				{ "name": "update", "type": "method" },
+				{ "name": "updated", "type": "method" }
+			],
+			"lit-static-properties": [
+				{ "name": "properties", "static": true },
+				{ "name": "styles", "static": true }
+			]
+		},
+		"accessorPairPositioning": "getThenSet"
+	}]
+};
+
 module.exports = {
 	"extends": "./browser-config.js",
 	"env": {
 		"es6": true
 	},
 	"plugins": [
-		"lit"
+		"lit",
+		"sort-class-members"
 	],
 	"rules": {
 		"arrow-spacing": 2,
@@ -31,6 +69,7 @@ module.exports = {
 		"lit/no-template-bind": 2,
 		"lit/no-template-map": 0,
 		"lit/no-useless-template-literals": 2,
-		"lit/no-value-attribute": 2
+		"lit/no-value-attribute": 2,
+		...litSortMemberRules
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brightspace",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Common Brightspace eslint configs.",
   "main": "index.js",
   "scripts": {

--- a/polymer-3-config.js
+++ b/polymer-3-config.js
@@ -1,4 +1,4 @@
-const { polymerSortMemberRules } = require('./polymer-sort-member-config');
+const { sortMemberRules } = require('./polymer-sort-member-config');
 
 module.exports = {
 	"extends": "./browser-config.js",
@@ -7,6 +7,6 @@ module.exports = {
 	],
 	"rules": {
 		"strict": 0,
-		...polymerSortMemberRules
+		...sortMemberRules
 	}
 };

--- a/polymer-3-config.js
+++ b/polymer-3-config.js
@@ -1,6 +1,12 @@
+const { polymerSortMemberRules } = require('./polymer-sort-member-config');
+
 module.exports = {
 	"extends": "./browser-config.js",
+	"plugins": [
+		"sort-class-members"
+	],
 	"rules": {
-		"strict": 0
+		"strict": 0,
+		...polymerSortMemberRules
 	}
 };

--- a/polymer-config.js
+++ b/polymer-config.js
@@ -1,6 +1,12 @@
+const { polymerSortMemberRules } = require('./polymer-sort-member-config');
+
 module.exports = {
-  "extends": "./browser-config.js",
-  "rules": {
-    "strict": 0
-  }
+	"extends": "./browser-config.js",
+	"plugins": [
+		"sort-class-members"
+	],
+	"rules": {
+		"strict": 0,
+		...polymerSortMemberRules
+	}
 };

--- a/polymer-config.js
+++ b/polymer-config.js
@@ -1,4 +1,4 @@
-const { polymerSortMemberRules } = require('./polymer-sort-member-config');
+const { sortMemberRules } = require('./polymer-sort-member-config');
 
 module.exports = {
 	"extends": "./browser-config.js",
@@ -7,6 +7,6 @@ module.exports = {
 	],
 	"rules": {
 		"strict": 0,
-		...polymerSortMemberRules
+		...sortMemberRules
 	}
 };

--- a/polymer-sort-member-config.js
+++ b/polymer-sort-member-config.js
@@ -1,26 +1,20 @@
-const { sortMemberGroups } = require('./sort-member-config');
+const { getSortMemberRules } = require('./sort-member-config');
 
-module.exports.polymerSortMemberRules = {
-	"sort-class-members/sort-class-members": [2, {
-		"order": [
-			"[static-property-is]",
-			"[static-property-properties]",
-			"[static-property-styles]",
-			"[static-properties]",
-			"[static-methods]",
-			"[properties]",
-			"constructor",
-			"[accessor-pairs]",
-			"[methods]",
-			"[private-accessor-pairs]",
-			"[private-properties]",
-			"[private-methods]"
-		],
-		"groups": { ...sortMemberGroups,
-			"static-property-is": [{ "name": "is", "static": true }],
-			"static-property-properties": [{ "name": "properties", "static": true }],
-			"static-property-styles":  [{ "name": "styles", "static": true }]
-		},
-		"accessorPairPositioning": "getThenSet"
-	}]
-};
+module.exports.sortMemberRules = getSortMemberRules([
+	"[static-property-is]",
+	"[static-property-properties]",
+	"[static-property-styles]",
+	"[static-properties]",
+	"[static-methods]",
+	"[properties]",
+	"constructor",
+	"[accessor-pairs]",
+	"[methods]",
+	"[private-accessor-pairs]",
+	"[private-properties]",
+	"[private-methods]"
+], {
+	"static-property-is": [{ "name": "is", "static": true }],
+	"static-property-properties": [{ "name": "properties", "static": true }],
+	"static-property-styles":  [{ "name": "styles", "static": true }]
+});

--- a/polymer-sort-member-config.js
+++ b/polymer-sort-member-config.js
@@ -1,0 +1,25 @@
+const { sortMemberRules } = require('./sort-member-config');
+
+module.exports.polymerSortMemberRules = {
+	"sort-class-members/sort-class-members": [2, {
+		"order": [
+			"[static-property-is]",
+			"[static-property-properties]",
+			"[static-property-styles]",
+			"[static-properties]",
+			"[static-methods]",
+			"[properties]",
+			"constructor",
+			"[accessor-pairs]",
+			"[methods]",
+			"[conventional-private-properties]",
+			"[conventional-private-methods]"
+		],
+		"groups": { ...sortMemberRules.groups,
+			"static-property-is": [{ "name": "is", "static": true }],
+			"static-property-properties": [{ "name": "properties", "static": true }],
+			"static-property-styles":  [{ "name": "styles", "static": true }]
+		},
+		"accessorPairPositioning": "getThenSet"
+	}]
+};

--- a/polymer-sort-member-config.js
+++ b/polymer-sort-member-config.js
@@ -1,4 +1,4 @@
-const { sortMemberRules } = require('./sort-member-config');
+const { sortMemberGroups } = require('./sort-member-config');
 
 module.exports.polymerSortMemberRules = {
 	"sort-class-members/sort-class-members": [2, {
@@ -12,10 +12,11 @@ module.exports.polymerSortMemberRules = {
 			"constructor",
 			"[accessor-pairs]",
 			"[methods]",
-			"[conventional-private-properties]",
-			"[conventional-private-methods]"
+			"[private-accessor-pairs]",
+			"[private-properties]",
+			"[private-methods]"
 		],
-		"groups": { ...sortMemberRules.groups,
+		"groups": { ...sortMemberGroups,
 			"static-property-is": [{ "name": "is", "static": true }],
 			"static-property-properties": [{ "name": "properties", "static": true }],
 			"static-property-styles":  [{ "name": "styles", "static": true }]

--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -1,4 +1,4 @@
-const groups = {
+const defaultGroups = {
 	"accessor-pairs": [{ "accessorPair": true, "sort": "alphabetical" }],
 	"methods": [{ "type": "method", "sort": "alphabetical" }],
 	"private-accessor-pairs": [{ "name": "/_.+/", "accessorPair": true, "sort": "alphabetical" }],
@@ -9,22 +9,24 @@ const groups = {
 	"static-properties": [{ "type": "property", "sort": "alphabetical", "static": true }]
 };
 
-module.exports.sortMemberGroups = groups;
+const defaultOrder = [
+	"[static-properties]",
+	"[static-methods]",
+	"[properties]",
+	"constructor",
+	"[accessor-pairs]",
+	"[methods]",
+	"[private-properties]",
+	"[private-accessor-pairs]",
+	"[private-methods]"
+];
 
-module.exports.sortMemberRules = {
-	"sort-class-members/sort-class-members": [2, {
-		"order": [
-			"[static-properties]",
-			"[static-methods]",
-			"[properties]",
-			"constructor",
-			"[accessor-pairs]",
-			"[methods]",
-			"[private-properties]",
-			"[private-accessor-pairs]",
-			"[private-methods]"
-		],
-		"groups": groups,
-		"accessorPairPositioning": "getThenSet"
-	}]
+module.exports.getSortMemberRules = (order, groups) => {
+	return {
+		"sort-class-members/sort-class-members": [2, {
+			"order": order ? order : defaultOrder,
+			"groups": {...defaultGroups, ...groups},
+			"accessorPairPositioning": "getThenSet"
+		}]
+	};
 };

--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -1,3 +1,16 @@
+const groups = {
+	"accessor-pairs": [{ "accessorPair": true, "sort": "alphabetical" }],
+	"methods": [{ "type": "method", "sort": "alphabetical" }],
+	"private-accessor-pairs": [{ "name": "/_.+/", "accessorPair": true, "sort": "alphabetical" }],
+	"private-methods": [{ "name": "/_.+/", "type": "method", "sort": "alphabetical" }],
+	"private-properties": [{ "name": "/_.+/", "type": "property", "sort": "alphabetical" }],
+	"properties": [{ "type": "property", "sort": "alphabetical" }],
+	"static-methods": [{ "type": "method", "sort": "alphabetical", "static": true }],
+	"static-properties": [{ "type": "property", "sort": "alphabetical", "static": true }]
+};
+
+module.exports.sortMemberGroups = groups;
+
 module.exports.sortMemberRules = {
 	"sort-class-members/sort-class-members": [2, {
 		"order": [
@@ -7,18 +20,11 @@ module.exports.sortMemberRules = {
 			"constructor",
 			"[accessor-pairs]",
 			"[methods]",
-			"[conventional-private-properties]",
-			"[conventional-private-methods]"
+			"[private-properties]",
+			"[private-accessor-pairs]",
+			"[private-methods]"
 		],
-		"groups": {
-			"accessor-pairs": [{ "accessorPair": true, "sort": "alphabetical" }],
-			"methods": [{ "type": "method", "sort": "alphabetical"}],
-			"conventional-private-methods": [{ "name": "/_.+/", "type": "method", "sort": "alphabetical"}],
-			"conventional-private-properties": [{ "name": "/_.+/", "type": "property", "sort": "alphabetical"}],
-			"properties": [{ "type": "property", "sort": "alphabetical"}],
-			"static-methods": [{ "type": "method", "sort": "alphabetical", "static": true }],
-			"static-properties": [{ "type": "property", "sort": "alphabetical", "static": true }]
-		},
+		"groups": groups,
 		"accessorPairPositioning": "getThenSet"
 	}]
 };

--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -1,9 +1,6 @@
 module.exports.sortMemberRules = {
 	"sort-class-members/sort-class-members": [2, {
 		"order": [
-			"[static-property-is]",
-			"[static-property-properties]",
-			"[static-property-styles]",
 			"[static-properties]",
 			"[static-methods]",
 			"[properties]",
@@ -11,20 +8,17 @@ module.exports.sortMemberRules = {
 			"[accessor-pairs]",
 			"[methods]",
 			"[conventional-private-properties]",
-			"[conventional-private-methods]",
+			"[conventional-private-methods]"
 		],
 		"groups": {
 			"accessor-pairs": [{ "accessorPair": true, "sort": "alphabetical" }],
 			"methods": [{ "type": "method", "sort": "alphabetical"}],
-			"conventional-private-methods": [{ "type": "method", "sort": "alphabetical"}],
-			"conventional-private-properties": [{ "type": "property", "sort": "alphabetical"}],
+			"conventional-private-methods": [{ "name": "/_.+/", "type": "method", "sort": "alphabetical"}],
+			"conventional-private-properties": [{ "name": "/_.+/", "type": "property", "sort": "alphabetical"}],
 			"properties": [{ "type": "property", "sort": "alphabetical"}],
 			"static-methods": [{ "type": "method", "sort": "alphabetical", "static": true }],
-			"static-properties": [{ "type": "property", "sort": "alphabetical", "static": true }],
-			"static-property-is": [{ "name": "is", "static": true }],
-			"static-property-properties": [{ "name": "properties", "static": true }],
-			"static-property-styles":  [{ "name": "styles", "static": true }]
+			"static-properties": [{ "type": "property", "sort": "alphabetical", "static": true }]
 		},
-		"accessorPairPositioning": "getThenSet",
+		"accessorPairPositioning": "getThenSet"
 	}]
-}
+};


### PR DESCRIPTION
* Refactors common sort member groups so they can be shared
* Defines sort rules specific for Lit and Polymer
* Fixes name pattern for conventional private members which was previously causing sort order to get ignored in some cases

This change will likely cause linting errors for several repos where incorrect sort order was previously not being caught.