### PR TITLE
Object curly spacing

### DIFF
--- a/common-config.js
+++ b/common-config.js
@@ -19,8 +19,8 @@ module.exports = {
     "no-trailing-spaces": 2, // nr
     "no-undef": 2,
     "no-unreachable": 2,
-	"no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
-	"object-curly-spacing": [2, "always"],
+    "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+    "object-curly-spacing": [2, "always"],
     "prefer-const": 2, // nr
     "quotes": [2, "single", "avoid-escape"], // nr
     "semi": 2, // nr

--- a/common-config.js
+++ b/common-config.js
@@ -19,7 +19,8 @@ module.exports = {
     "no-trailing-spaces": 2, // nr
     "no-undef": 2,
     "no-unreachable": 2,
-    "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+	"no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+	"object-curly-spacing": [2, "always"],
     "prefer-const": 2, // nr
     "quotes": [2, "single", "avoid-escape"], // nr
     "semi": 2, // nr

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brightspace",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Common Brightspace eslint configs.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brightspace",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Common Brightspace eslint configs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added [object-curly-spacing](https://eslint.org/docs/rules/object-curly-spacing)

`This rule enforces consistent spacing inside braces of object literals, destructuring assignments, and import/export specifiers.`