### PR TITLE
Add no-use-before-define for variables and classes

### DIFF
--- a/common-config.js
+++ b/common-config.js
@@ -20,6 +20,7 @@ module.exports = {
     "no-undef": 2,
     "no-unreachable": 2,
     "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+    "no-use-before-define": [2, "nofunc"], // nr
     "object-curly-spacing": [2, "always"],
     "prefer-const": 2, // nr
     "quotes": [2, "single", "avoid-escape"], // nr

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brightspace",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Common Brightspace eslint configs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Tackling a story we've had sitting around for a while.  Having this linting rule would have saved us from a my courses hotfix after we toggled on some very old code triggered by a very specific edge case.  Thoughts?

https://eslint.org/docs/rules/no-use-before-define