### PR TITLE
Upgrade to @babel/eslint-parser to support dynamic imports

### DIFF
--- a/browser-config.js
+++ b/browser-config.js
@@ -2,7 +2,10 @@ const { getSortMemberRules } = require('./sort-member-config');
 
 module.exports = {
 	"extends": "./index.js",
-	"parser": "babel-eslint",
+	"parser": "@babel/eslint-parser",
+	"parserOptions": {
+		"requireConfigFile": false
+  },
 	"env": {
 		"browser": true
 	},


### PR DESCRIPTION
[babel-eslint](https://github.com/babel/babel-eslint) has moved to [@babel/eslint-parser](https://github.com/babel/babel/tree/main/eslint/babel-eslint-parser)