### PR TITLE
Add @babel/eslint-parser as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/Brightspace/eslint-config-brightspace",
   "peerDependencies": {
-    "eslint": "^5 || ^6 || ^7"
+    "@babel/eslint-parser": "^7",
+    "eslint": "^7"
   }
 }


### PR DESCRIPTION
Should have done this with `0.13.0` but this will make it clearer earlier that it's required, and with npm 7 it will install it automatically.