### PR TITLE
feat: Add private accessors group to sort-member-config

### DIFF
--- a/lit-config.js
+++ b/lit-config.js
@@ -10,6 +10,7 @@ const sortMemberRules = getSortMemberRules([
 	"[lit-methods]",
 	"[methods]",
 	"[private-accessor-pairs]",
+	"[private-accessors]",
 	"[private-properties]",
 	"[private-methods]"
 ], {

--- a/polymer-sort-member-config.js
+++ b/polymer-sort-member-config.js
@@ -11,6 +11,7 @@ module.exports.sortMemberRules = getSortMemberRules([
 	"[accessor-pairs]",
 	"[methods]",
 	"[private-accessor-pairs]",
+	"[private-accessors]",
 	"[private-properties]",
 	"[private-methods]"
 ], {

--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -2,6 +2,7 @@ const defaultGroups = {
 	"accessor-pairs": [{ "accessorPair": true, "sort": "alphabetical" }],
 	"methods": [{ "type": "method", "sort": "alphabetical" }],
 	"private-accessor-pairs": [{ "name": "/_.+/", "accessorPair": true, "sort": "alphabetical" }],
+	"private-accessors": [{ "name": "/_.+/", "kind": "get", "accessorPair": false, "sort": "alphabetical" }, { "name": "/_.+/", "kind": "set", "accessorPair": false, "sort": "alphabetical" }],
 	"private-methods": [{ "name": "/_.+/", "type": "method", "sort": "alphabetical" }],
 	"private-properties": [{ "name": "/_.+/", "type": "property", "sort": "alphabetical" }],
 	"properties": [{ "type": "property", "sort": "alphabetical" }],
@@ -18,6 +19,7 @@ const defaultOrder = [
 	"[methods]",
 	"[private-properties]",
 	"[private-accessor-pairs]",
+	"[private-accessors]",
 	"[private-methods]"
 ];
 


### PR DESCRIPTION
## Summary
While using `lit-config` extension in our project, I realized that having non-paired private accessors (i.e. private getter with no setter or vice versa) would intertwine the private accessors and private methods when sorting. So I added another group called "private-accessors" which sorts standalone getters first then sorts standalone setters second. See below for a better explanation.

This was the behaviour **before** this change:
```js
// private accessor pairs group
get _method4() {}
set _method4(arg) {}

// private methods group
get _method1() {} // <-- private getter falls under "private-methods" group
_method2() {} // <-- private method
set _method3(arg) {} // <-- private setter falls under "private-methods" group
get _method5() {} // <-- private getter falls under "private-methods" group
```

This is the behaviour **after** this change:
```js
// private accessor pairs group
get _method4() {}
set _method4(arg) {}

// *NEW* private accessors group
get _method1() {} // <-- getters sorted first
get _method5() {}
set _method3(arg) {} // <-- setters sorted second

// private methods group
_method2() {}
```