### PR TITLE
fix: Add public accessors group to sort-member-config

### DIFF
--- a/lit-config.js
+++ b/lit-config.js
@@ -7,6 +7,7 @@ const sortMemberRules = getSortMemberRules([
 	"[properties]",
 	"constructor",
 	"[accessor-pairs]",
+	"[accessors]",
 	"[lit-methods]",
 	"[methods]",
 	"[private-accessor-pairs]",

--- a/polymer-sort-member-config.js
+++ b/polymer-sort-member-config.js
@@ -9,6 +9,7 @@ module.exports.sortMemberRules = getSortMemberRules([
 	"[properties]",
 	"constructor",
 	"[accessor-pairs]",
+	"[accessors]",
 	"[methods]",
 	"[private-accessor-pairs]",
 	"[private-accessors]",

--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -1,5 +1,6 @@
 const defaultGroups = {
 	"accessor-pairs": [{ "accessorPair": true, "sort": "alphabetical" }],
+	"accessors": [{ "kind": "get", "accessorPair": false, "sort": "alphabetical" }, { "kind": "set", "accessorPair": false, "sort": "alphabetical" }],
 	"methods": [{ "type": "method", "sort": "alphabetical" }],
 	"private-accessor-pairs": [{ "name": "/_.+/", "accessorPair": true, "sort": "alphabetical" }],
 	"private-accessors": [{ "name": "/_.+/", "kind": "get", "accessorPair": false, "sort": "alphabetical" }, { "name": "/_.+/", "kind": "set", "accessorPair": false, "sort": "alphabetical" }],
@@ -16,6 +17,7 @@ const defaultOrder = [
 	"[properties]",
 	"constructor",
 	"[accessor-pairs]",
+	"[accessors]",
 	"[methods]",
 	"[private-properties]",
 	"[private-accessor-pairs]",


### PR DESCRIPTION
## Summary
I encountered the same exact issue with standalone public accessors as I did with private accessors in #41.