### PR TITLE
feat: restoring the "import" plugin but ignoring packages this time

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To use `react-config`, consumers should install the [eslint-plugin-react](https:
 
 To use `polymer-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) plugin to extract and lint JavaScript contained in `.html` web component files. [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) plugin is required to ensure consistency in class format
 
-To use `lit-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html), [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members), and [eslint-plugin-lit](https://github.com/43081j/eslint-plugin-lit) plugins.
+To use `lit-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html), [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) [eslint-plugin-lit](https://github.com/43081j/eslint-plugin-lit) and [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) plugins.
 
 See the [eslint rules](http://eslint.org/docs/rules/) for more details on rule configuration.  See the [eslint shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) for more details on creating configs.
 

--- a/lit-config.js
+++ b/lit-config.js
@@ -38,6 +38,7 @@ module.exports = {
 		"es6": true
 	},
 	"plugins": [
+		"import",
 		"lit",
 		"sort-class-members"
 	],
@@ -54,6 +55,7 @@ module.exports = {
 		"prefer-template": 2,
 		"sort-imports": [2, { "ignoreCase": true }],
 		"strict": [2, "never"],
+		"import/extensions": ["error", "ignorePackages"],
 		"lit/attribute-value-entities": 2,
 		"lit/binding-positions": 2,
 		"lit/no-duplicate-template-bindings": 2,


### PR DESCRIPTION
Attempt 2. The `ignorePackages` flag appears to do exactly what we want, in that it'll allow `import { LitElement } from 'lit-element';` (a package) but catch file imports that are missing extensions. Hat-tip to @svanherk for noticing it. 🎩 