### PR TITLE
fix: future-proof peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Brightspace/eslint-config-brightspace",
   "peerDependencies": {
-    "@babel/eslint-parser": "^7",
-    "eslint": "^7"
+    "@babel/eslint-parser": ">= 7",
+    "eslint": ">= 7"
   }
 }


### PR DESCRIPTION
I upgraded a few repos to use eslint version 8, and now I'm seeing warnings about our config requiring eslint 7. Their [documentation](https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config) recommends using the `>=` syntax to future-proof your configs.