### PR TITLE
feat: adjust how `null` `eqeqeq` rule works

### DIFF
--- a/common-config.js
+++ b/common-config.js
@@ -5,7 +5,7 @@ module.exports = {
   "rules": {
     "comma-spacing": 2, // nr
     "eol-last": 2, // nr
-    "eqeqeq": 2, // nr
+    "eqeqeq": [2, "always", { "null": "ignore" }], // nr
     "indent": [2, "tab", { "SwitchCase": 1 }], // nr
     "linebreak-style": ["error", "unix"], // nr
     "new-parens": 2, // nr


### PR DESCRIPTION
Allow `==` for `null` literal to avoid the need to do `value !== null && value !== undefined` whenever wanting to check if the `value` exists without accidently having `0` and `false` be included in that check (i.e. doing `if (!value)`). This still requires `===` for all other cases. Tried this with rubrics and the behaviour worked as desired
https://eslint.org/docs/rules/eqeqeq#allow-null