### PR TITLE
feat: moving some settings from lit to browser config

### DIFF
--- a/browser-config.js
+++ b/browser-config.js
@@ -5,19 +5,33 @@ module.exports = {
 	"parser": "@babel/eslint-parser",
 	"parserOptions": {
 		"requireConfigFile": false
-  },
+	},
 	"env": {
-		"browser": true
+		"browser": true,
+		"es2021": true
 	},
 	"plugins": [
 		"html",
+		"import",
 		"sort-class-members"
 	],
 	"globals": {
-		"D2L": false,
-		"Promise": false
+		"D2L": false
 	},
 	"rules": {
+		"arrow-spacing": 2,
+		"no-confusing-arrow": 2,
+		"no-duplicate-imports": 2,
+		"no-restricted-syntax": ["error", "CatchClause[param=null]"],
+		"no-useless-constructor": 2,
+		"no-var": 2,
+		"prefer-arrow-callback": 2,
+		"prefer-const": 2,
+		"prefer-spread": 2,
+		"prefer-template": 2,
+		"sort-imports": [2, { "ignoreCase": true }],
+		"strict": [2, "never"],
+		"import/extensions": ["error", "ignorePackages"],
 		"no-console": ["error", { "allow": ["warn", "error"] }],
 		...getSortMemberRules()
 	}

--- a/lit-config.js
+++ b/lit-config.js
@@ -34,28 +34,12 @@ const sortMemberRules = getSortMemberRules([
 
 module.exports = {
 	"extends": "./browser-config.js",
-	"env": {
-		"es6": true
-	},
 	"plugins": [
 		"import",
 		"lit",
 		"sort-class-members"
 	],
 	"rules": {
-		"arrow-spacing": 2,
-		"no-confusing-arrow": 2,
-		"no-duplicate-imports": 2,
-		"no-restricted-syntax": ["error", "CatchClause[param=null]"],
-		"no-useless-constructor": 2,
-		"no-var": 2,
-		"prefer-arrow-callback": 2,
-		"prefer-const": 2,
-		"prefer-spread": 2,
-		"prefer-template": 2,
-		"sort-imports": [2, { "ignoreCase": true }],
-		"strict": [2, "never"],
-		"import/extensions": ["error", "ignorePackages"],
 		"lit/attribute-value-entities": 2,
 		"lit/binding-positions": 2,
 		"lit/no-duplicate-template-bindings": 2,


### PR DESCRIPTION
I've been working in a non-Lit context for the past few days in repos that just use the `browser-config`. I noticed that a lot of the rules we're used to in Lit aren't being applied. This moves a lot of the browser-y things from the Lit config up to its parent. 

I ran this in core and this resulted in no errors, as expected. But this could have a pretty big impact on repos using the browser config directly, or the Polymer configs indirectly -- it'll be a minor (which is major at `0.x`) bump for that reason.