### PR TITLE
chore(common-configs): enable `curly`

### DIFF
--- a/common-config.js
+++ b/common-config.js
@@ -4,6 +4,7 @@
 module.exports = {
   "rules": {
     "comma-spacing": 2, // nr
+    "curly": 2, // nr
     "eol-last": 2, // nr
     "eqeqeq": [2, "always", { "null": "ignore" }], // nr
     "indent": [2, "tab", { "SwitchCase": 1 }], // nr


### PR DESCRIPTION
This seems like a good practice.

> JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to _never_ omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity.
> ~https://eslint.org/docs/latest/rules/curly

~Random real-life example of where braces could have prevented a major bug: https://nakedsecurity.sophos.com/2014/02/24/anatomy-of-a-goto-fail-apples-ssl-bug-explained-plus-an-unofficial-patch/.

This also matches LMS C# behaviour: https://github.com/Brightspace/lms/blob/23a65abcb6f1afc988b3ef81b02ce312f7f742c3/.editorconfig#L82

Thoughts?