### PR TITLE
feat: add no-absolute-path plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ Specify the desired config for the `extends` property:
 }
 ```
 
-To use `react-config`, consumers should install the [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) plugin to enable use of the rules it provides.
-
-To use `polymer-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) plugin to extract and lint JavaScript contained in `.html` web component files. [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) plugin is required to ensure consistency in class format
-
-To use `lit-config`, consumers should install the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html), [eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) [eslint-plugin-lit](https://github.com/43081j/eslint-plugin-lit) and [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) plugins.
-
 See the [eslint rules](http://eslint.org/docs/rules/) for more details on rule configuration.  See the [eslint shareable configs](http://eslint.org/docs/developer-guide/shareable-configs.html) for more details on creating configs.
 
 ## Contributing

--- a/browser-config.js
+++ b/browser-config.js
@@ -32,6 +32,7 @@ module.exports = {
 		"sort-imports": [2, { "ignoreCase": true }],
 		"strict": [2, "never"],
 		"import/extensions": ["error", "ignorePackages"],
+		"import/no-absolute-path": 2,
 		"no-console": ["error", { "allow": ["warn", "error"] }],
 		...getSortMemberRules()
 	}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   "homepage": "https://github.com/Brightspace/eslint-config-brightspace",
   "peerDependencies": {
     "@babel/eslint-parser": ">= 7",
-    "eslint": ">= 7"
+    "eslint": ">= 7",
+    "eslint-plugin-html": "^7",
+    "eslint-plugin-import": "^2",
+    "eslint-plugin-lit": "^1",
+    "eslint-plugin-sort-class-members": "^1"
   }
 }


### PR DESCRIPTION
Imports with absolute paths have broken a few BSI builds lately, so it was time to make this a linting error scenario [using this plugin](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-absolute-path.md).

I'm also making the plugins used by our config `peerDependencies`, which NPM >= 7 will install automatically and removes the need for consumers to list these as project dependencies. This shouldn't make our eventual migration to the [new config file format](https://eslint.org/blog/2022/08/new-config-system-part-1/) any more difficult.