### PR TITLE
feat: add rule `no-unneeded-ternary`

### DIFF
--- a/common-config.js
+++ b/common-config.js
@@ -7,6 +7,7 @@ module.exports = {
     "eol-last": 2, // nr
     "eqeqeq": [2, "always", { "null": "ignore" }], // nr
     "indent": [2, "tab", { "SwitchCase": 1 }], // nr
+    "keyword-spacing": 2,
     "linebreak-style": ["error", "unix"], // nr
     "new-parens": 2, // nr
     "no-debugger": 2,
@@ -19,6 +20,7 @@ module.exports = {
     "no-multiple-empty-lines": [2, {"max": 1}], // nr
     "no-trailing-spaces": 2, // nr
     "no-undef": 2,
+    "no-unneeded-ternary": 2, // nr
     "no-unreachable": 2,
     "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
     "no-use-before-define": [2, "nofunc"], // nr
@@ -26,7 +28,6 @@ module.exports = {
     "prefer-const": 2, // nr
     "quotes": [2, "single", "avoid-escape"], // nr
     "semi": 2, // nr
-    "keyword-spacing": 2,
     "space-before-blocks": [2, "always"], // nr
     "space-before-function-paren": [2, "never"], //nr
     "space-in-parens": [2, "never"],


### PR DESCRIPTION
Prevents stuff like `temp1 == temp2 ? true : false`. Can also be auto fixed in most simple cases.
https://eslint.org/docs/latest/rules/no-unneeded-ternary