### PR TITLE
chore(common-config): add `no-new-wrappers`.

### DIFF
--- a/common-config.js
+++ b/common-config.js
@@ -18,6 +18,7 @@ module.exports = {
     "no-fallthrough": 2,
     "no-invalid-this": 2, // nr
     "no-multiple-empty-lines": [2, {"max": 1}], // nr
+	"no-new-wrappers": 2, // nr
     "no-trailing-spaces": 2, // nr
     "no-undef": 2,
     "no-unneeded-ternary": 2, // nr


### PR DESCRIPTION
Quick search suggests this is a recommend rule:

> Although possible, there aren’t any good reasons to use these primitive wrappers as constructors. They tend to confuse other developers more than anything else because they seem like they should act as primitives, but they do not.
> ~https://eslint.org/docs/latest/rules/no-new-wrappers

> Never use new on the primitive object wrappers (Boolean, Number, String, Symbol), nor include them in type annotations.
> ~https://google.github.io/styleguide/jsguide.html#disallowed-features-wrapper-objects

Happy to just close the PR if we don't quickly trend towards an obvious "we should add this".