### PR TITLE
Update node-config to use es2022

### DIFF
--- a/node-config.js
+++ b/node-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   "extends": "./index.js",
   "env": {
-    "es2017": true,
+    "es2022": true,
     "node": true
   }
 };


### PR DESCRIPTION
Updating the node-config to use latest version es2022 which introduces support for top-level await.

Relevant docs: https://eslint.org/docs/latest/use/configure/language-options