### PR TITLE
jprouse/US153861-double-spaces-rule

### DIFF
--- a/browser-config.js
+++ b/browser-config.js
@@ -34,6 +34,7 @@ module.exports = {
 		"import/extensions": ["error", "ignorePackages"],
 		"import/no-absolute-path": 2,
 		"no-console": ["error", { "allow": ["warn", "error"] }],
+		"no-multi-spaces": "error",
 		...getSortMemberRules()
 	}
 };

--- a/browser-config.js
+++ b/browser-config.js
@@ -34,7 +34,6 @@ module.exports = {
 		"import/extensions": ["error", "ignorePackages"],
 		"import/no-absolute-path": 2,
 		"no-console": ["error", { "allow": ["warn", "error"] }],
-		"no-multi-spaces": 2,
 		...getSortMemberRules()
 	}
 };

--- a/browser-config.js
+++ b/browser-config.js
@@ -34,7 +34,7 @@ module.exports = {
 		"import/extensions": ["error", "ignorePackages"],
 		"import/no-absolute-path": 2,
 		"no-console": ["error", { "allow": ["warn", "error"] }],
-		"no-multi-spaces": "error",
+		"no-multi-spaces": 2,
 		...getSortMemberRules()
 	}
 };

--- a/common-config.js
+++ b/common-config.js
@@ -18,6 +18,7 @@ module.exports = {
     "no-fallthrough": 2,
     "no-invalid-this": 2, // nr
     "no-multiple-empty-lines": [2, {"max": 1}], // nr
+	"no-multi-spaces": 2, // nr
 	"no-new-wrappers": 2, // nr
     "no-trailing-spaces": 2, // nr
     "no-undef": 2,


### PR DESCRIPTION
Rally Story: https://rally1.rallydev.com/#/?detail=/userstory/704556573471&fdp=true

Hi Gaudi, we are adding the [no-multi-spaces](https://eslint.org/docs/latest/rules/no-multi-spaces) rule to one of our repos and thought to check here and see if this is something useful for any of the existing configs (we currently use the browser-config a lot). We're aiming to avoid making custom rules in the eslint files in all our projects but no harm if this isn't desired 😄 