### PR TITLE
feat(common-config): add 'no-var' to all contexts.

### DIFF
--- a/browser-config.js
+++ b/browser-config.js
@@ -24,7 +24,6 @@ module.exports = {
 		"no-duplicate-imports": 2,
 		"no-restricted-syntax": ["error", "CatchClause[param=null]"],
 		"no-useless-constructor": 2,
-		"no-var": 2,
 		"prefer-arrow-callback": 2,
 		"prefer-const": 2,
 		"prefer-spread": 2,

--- a/browser-config.js
+++ b/browser-config.js
@@ -25,7 +25,6 @@ module.exports = {
 		"no-restricted-syntax": ["error", "CatchClause[param=null]"],
 		"no-useless-constructor": 2,
 		"prefer-arrow-callback": 2,
-		"prefer-const": 2,
 		"prefer-spread": 2,
 		"prefer-template": 2,
 		"sort-imports": [2, { "ignoreCase": true }],

--- a/common-config.js
+++ b/common-config.js
@@ -26,6 +26,7 @@ module.exports = {
     "no-unreachable": 2,
     "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
     "no-use-before-define": [2, "nofunc"], // nr
+	"no-var": 2, // nr
     "object-curly-spacing": [2, "always"],
     "prefer-const": 2, // nr
     "quotes": [2, "single", "avoid-escape"], // nr


### PR DESCRIPTION
I believe `let` or `const` is preferred over `var` in most situations. Thoughts on enabling `no-var` for everyone?

I'm coming from Node.js so alternatively, thoughts on enabling it for `node-config` if not for everyone?