### PR TITLE
Add additional lit lifecycle methods

### DIFF
--- a/lit-config.js
+++ b/lit-config.js
@@ -16,15 +16,19 @@ const sortMemberRules = getSortMemberRules([
 	"[private-methods]"
 ], {
 	"lit-methods": [
+		{ "name": "adoptedCallback", "type": "method" },
 		{ "name": "attributeChangedCallback", "type": "method" },
 		{ "name": "connectedCallback", "type": "method" },
 		{ "name": "disconnectedCallback", "type": "method" },
 		{ "name": "firstUpdated", "type": "method" },
+		{ "name": "getUpdateComplete", "type": "method" },
 		{ "name": "performUpdate", "type": "method" },
 		{ "name": "render", "type": "method" },
+		{ "name": "scheduleUpdate", "type": "method" },
 		{ "name": "shouldUpdate", "type": "method" },
 		{ "name": "update", "type": "method" },
-		{ "name": "updated", "type": "method" }
+		{ "name": "updated", "type": "method" },
+		{ "name": "willUpdate", "type": "method" }
 	],
 	"lit-static-properties": [
 		{ "name": "properties", "static": true },


### PR DESCRIPTION
We're making use of `willUpdate` in folio-app and noticed that our linting config doesn't treat it as a lit lifecycle method. Adding a few others from the documentation while I'm here.