### PR TITLE
Disable quotes rule for lang files

### DIFF
--- a/lit-config.js
+++ b/lit-config.js
@@ -44,7 +44,7 @@ module.exports = {
 		"sort-class-members"
 	],
 	"overrides": [{
-		"files": "./lang/*.js",	
+		"files": "./**/lang/*.js",	
 		"rules": {
 			"quotes": 0
 		}

--- a/lit-config.js
+++ b/lit-config.js
@@ -43,6 +43,12 @@ module.exports = {
 		"lit",
 		"sort-class-members"
 	],
+	"overrides": [{
+		"files": "./lang/*.js",	
+		"rules": {
+			"quotes": 0
+		}
+	}]
 	"rules": {
 		"lit/attribute-value-entities": 2,
 		"lit/binding-positions": 2,


### PR DESCRIPTION
Lang files currently use a mix of single quotes, double quotes, and backticks, and override the quotes rule either in each file or in their own eslint configs. This disables that rule globally so we don't need to do it everywhere manually.