### PR TITLE
GAUD-292 - Use new release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:
-          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM: true


### PR DESCRIPTION
The `brightspace-bot` and `D2L_GITHUB_TOKEN` are no longer needed for `release` workflows. Instead, we have a [new `D2L_RELEASE_TOKEN`](https://github.com/Brightspace/repo-settings/blob/main/docs/release_action_setup.md) that has the ability to bypass the repo ruleset (configured in https://github.com/Brightspace/repo-settings/pull/1537) and org-level ruleset.

Before merging, I will:
- Confirm the new ruleset matches the old branch protection rule before deleting it
- Remove `brightspace-bot` as a repo contributor
- Confirm the `D2L_RELEASE_TOKEN` is available and remove this repo's access to `D2L_GITHUB_TOKEN`