### PR TITLE
Do not require sorting class properties

### DIFF
--- a/sort-member-config.js
+++ b/sort-member-config.js
@@ -5,10 +5,10 @@ const defaultGroups = {
 	"private-accessor-pairs": [{ "name": "/_.+/", "accessorPair": true, "sort": "alphabetical" }],
 	"private-accessors": [{ "name": "/_.+/", "kind": "get", "accessorPair": false, "sort": "alphabetical" }, { "name": "/_.+/", "kind": "set", "accessorPair": false, "sort": "alphabetical" }],
 	"private-methods": [{ "name": "/_.+/", "type": "method", "sort": "alphabetical" }],
-	"private-properties": [{ "name": "/_.+/", "type": "property", "sort": "alphabetical" }],
-	"properties": [{ "type": "property", "sort": "alphabetical" }],
+	"private-properties": [{ "name": "/_.+/", "type": "property", "sort": "none" }],
+	"properties": [{ "type": "property", "sort": "none" }],
 	"static-methods": [{ "type": "method", "sort": "alphabetical", "static": true }],
-	"static-properties": [{ "type": "property", "sort": "alphabetical", "static": true }]
+	"static-properties": [{ "type": "property", "sort": "none", "static": true }]
 };
 
 const defaultOrder = [


### PR DESCRIPTION
Class properties cannot be required to be sorted because their initialization is executed in order and they may reference each other. I'm kind of baffled this is even an option.

It's equivalent to requiring these be sorted:
```js
const b = 1;
const a = b;
```