### PR TITLE
fix: allow eslint-plugin-html 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "peerDependencies": {
         "@babel/eslint-parser": ">= 7",
         "eslint": ">= 7",
-        "eslint-plugin-html": "^7",
+        "eslint-plugin-html": "^7 || ^8",
         "eslint-plugin-import": "^2",
         "eslint-plugin-lit": "^1",
         "eslint-plugin-sort-class-members": "^1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@babel/eslint-parser": ">= 7",
     "eslint": ">= 7",
-    "eslint-plugin-html": "^7",
+    "eslint-plugin-html": "^7 || ^8",
     "eslint-plugin-import": "^2",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1"


### PR DESCRIPTION
Version 7 seems to fail parsing when used with eslint9 flat configs. So bumping the version is necessary to update repos to eslint9. (e.g. this [update](https://github.com/BrightspaceUI/core/pull/5100) is currently failing because of the limit to the version).

[CHANGELOG.md](https://github.com/BenoitZugmeyer/eslint-plugin-html/blob/05bb69f7466f2077abf7ed9f9edf662c351fbd6e/CHANGELOG.md) lists as breaking changes only dropping node 12 and 14