### PR TITLE
Ignore unused rest vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ module.exports = {
 		"no-undef": 2,
 		"no-unneeded-ternary": 2, // nr
 		"no-unreachable": 2,
-		"no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+		"no-unused-vars": [2, {
+			"vars": "all",
+			"args": "after-used",
+			"ignoreRestSiblings": true
+		}],
 		"no-use-before-define": [2, "nofunc"], // nr
 		"no-var": 2, // nr
 		"object-curly-spacing": [2, "always"],


### PR DESCRIPTION
Running into a `no-unused-vars` error [here](https://github.com/BrightspaceUI/testing/pull/527/files#diff-12c5b59babab824650a00f2b88cd8eeb9fa04dbfed5bbed3e67b14b71ca9aae2R77) because the first item in a destructured object followed by a rest isn't used:

```javascript
const {a, ...b} = c;
return b;
```

This is just an immutable way to quickly filter an object, and is similar to the first unused argument of a function being ignored:

```javascript
function a(b, c) {
	return c + 1;
}
```