### PR TITLE
fix: Properly remove `no-restricted-syntax`

### DIFF
--- a/browser-config.js
+++ b/browser-config.js
@@ -22,7 +22,6 @@ module.exports = {
 		"arrow-spacing": 2,
 		"no-confusing-arrow": 2,
 		"no-duplicate-imports": 2,
-		"no-restricted-syntax": ["error", "CatchClause[param=null]"],
 		"no-useless-constructor": 2,
 		"prefer-arrow-callback": 2,
 		"prefer-spread": 2,

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ module.exports = {
 		"no-multiple-empty-lines": [2, {"max": 1}], // nr
 		"no-multi-spaces": 2, // nr
 		"no-new-wrappers": 2, // nr
-		"no-restricted-syntax": [0, "CatchClause[param=null]"],
 		"no-trailing-spaces": 2, // nr
 		"no-undef": 2,
 		"no-unneeded-ternary": 2, // nr


### PR DESCRIPTION
The `no-restricted-syntax` was not being set by the recommended rules but by an override on `browser-config.js`. The rule was explicitly set [here](https://github.com/Brightspace/eslint-config-brightspace/pull/28), at that point the syntax was not fully supported which now [is not the case](https://caniuse.com/?search=optional%20catch%20binding). 