### PR TITLE
Allow unused vars/args in destructured arrays

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -27,7 +27,8 @@ export default [js.configs.recommended, {
 		'no-unused-vars': [2, {
 			'vars': 'all',
 			'args': 'after-used',
-			'ignoreRestSiblings': true
+			'ignoreRestSiblings': true,
+			'destructuredArrayIgnorePattern': 'gc|^_'
 		}],
 		'no-use-before-define': [2, 'nofunc'], // nr
 		'no-var': 2, // nr


### PR DESCRIPTION
[GAUD-7526](https://desire2learn.atlassian.net/browse/GAUD-7526): eslint-config: Allow unused vars/args in destructured arrays

Allows vars/args in destructured arrays to be unused if they either start with `_` or are exactly `gc`.

Example:
```javascript
([gc, v]) => v === version
```
or
```javascript
const [_name, _phone, address] = user.profile;
```
where `_name` and `_phone` would never be used

[GAUD-7526]: https://desire2learn.atlassian.net/browse/GAUD-7526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ