### PR TITLE
GAUD-8404 - Add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      # update-package-lock workflow handles minor/patch updates - delay for a few weeks to give time to handle breaking changes in those PRs
+      default-days: 25
+      semver-major-days: 5


### PR DESCRIPTION
Because of the timing of `update-package-lock` in this repo, `dependabot` is constantly opening PRs before it can run. I actually thought this repo didn't have `update-package-lock`.

We're testing the cooldown configuration in `core`, but this repo can get it early.