### PR TITLE
Switch to using `@stylistic` equivilents

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -7,12 +7,7 @@ export default [js.configs.recommended, {
 		'@stylistic': stylistic
 	},
 	'rules': {
-		'@stylistic/comma-spacing': 2, // nr
-		'@stylistic/eol-last': 2, // nr
 		'eqeqeq': [2, 'always', { 'null': 'ignore' }], // nr
-		'@stylistic/keyword-spacing': 2,
-		'@stylistic/linebreak-style': ['error', 'unix'], // nr
-		'@stylistic/new-parens': 2, // nr
 		'no-debugger': 2,
 		'no-dupe-args': 2,
 		'no-dupe-keys': 2,
@@ -20,10 +15,7 @@ export default [js.configs.recommended, {
 		'no-ex-assign': 2,
 		'no-fallthrough': 2,
 		'no-invalid-this': 2, // nr
-		'@stylistic/no-multiple-empty-lines': [2, { 'max': 1 }], // nr
-		'@stylistic/no-multi-spaces': 2, // nr
 		'no-new-wrappers': 2, // nr
-		'@stylistic/no-trailing-spaces': 2, // nr
 		'no-undef': 2,
 		'no-unneeded-ternary': 2, // nr
 		'no-unreachable': 2,
@@ -35,16 +27,24 @@ export default [js.configs.recommended, {
 		}],
 		'no-use-before-define': [2, 'nofunc'], // nr
 		'no-var': 2, // nr
-		'@stylistic/object-curly-spacing': [2, 'always'],
 		'prefer-const': 2, // nr
+		'strict': [2, 'global'], // nr
+		'valid-typeof': 2,
+		'@stylistic/comma-spacing': 2, // nr
+		'@stylistic/eol-last': 2, // nr
+		'@stylistic/indent': [2, 'tab', { 'SwitchCase': 1 }], // nr
+		'@stylistic/keyword-spacing': 2,
+		'@stylistic/linebreak-style': ['error', 'unix'], // nr
+		'@stylistic/new-parens': 2, // nr
+		'@stylistic/no-multi-spaces': 2, // nr
+		'@stylistic/no-multiple-empty-lines': [2, { 'max': 1 }], // nr
+		'@stylistic/no-trailing-spaces': 2, // nr
+		'@stylistic/object-curly-spacing': [2, 'always'],
+		'@stylistic/quotes': [2, 'single', { 'avoidEscape': true }], // nr
 		'@stylistic/semi': 2, // nr
 		'@stylistic/space-before-blocks': [2, 'always'], // nr
 		'@stylistic/space-before-function-paren': [2, 'never'], //nr
 		'@stylistic/space-in-parens': [2, 'never'],
-		'@stylistic/space-infix-ops': 2, // nr
-		'strict': [2, 'global'], // nr
-		'valid-typeof': 2,
-		'@stylistic/indent': [2, 'tab', { 'SwitchCase': 1 }], // nr
-		'@stylistic/quotes': [2, 'single', { 'avoidEscape': true }] // nr
+		'@stylistic/space-infix-ops': 2 // nr
 	}
 }];

--- a/configs/base.js
+++ b/configs/base.js
@@ -7,12 +7,12 @@ export default [js.configs.recommended, {
 		'@stylistic': stylistic
 	},
 	'rules': {
-		'comma-spacing': 2, // nr
-		'eol-last': 2, // nr
+		'@stylistic/comma-spacing': 2, // nr
+		'@stylistic/eol-last': 2, // nr
 		'eqeqeq': [2, 'always', { 'null': 'ignore' }], // nr
-		'keyword-spacing': 2,
-		'linebreak-style': ['error', 'unix'], // nr
-		'new-parens': 2, // nr
+		'@stylistic/keyword-spacing': 2,
+		'@stylistic/linebreak-style': ['error', 'unix'], // nr
+		'@stylistic/new-parens': 2, // nr
 		'no-debugger': 2,
 		'no-dupe-args': 2,
 		'no-dupe-keys': 2,
@@ -20,10 +20,10 @@ export default [js.configs.recommended, {
 		'no-ex-assign': 2,
 		'no-fallthrough': 2,
 		'no-invalid-this': 2, // nr
-		'no-multiple-empty-lines': [2, { 'max': 1 }], // nr
-		'no-multi-spaces': 2, // nr
+		'@stylistic/no-multiple-empty-lines': [2, { 'max': 1 }], // nr
+		'@stylistic/no-multi-spaces': 2, // nr
 		'no-new-wrappers': 2, // nr
-		'no-trailing-spaces': 2, // nr
+		'@stylistic/no-trailing-spaces': 2, // nr
 		'no-undef': 2,
 		'no-unneeded-ternary': 2, // nr
 		'no-unreachable': 2,
@@ -35,13 +35,13 @@ export default [js.configs.recommended, {
 		}],
 		'no-use-before-define': [2, 'nofunc'], // nr
 		'no-var': 2, // nr
-		'object-curly-spacing': [2, 'always'],
+		'@stylistic/object-curly-spacing': [2, 'always'],
 		'prefer-const': 2, // nr
-		'semi': 2, // nr
-		'space-before-blocks': [2, 'always'], // nr
-		'space-before-function-paren': [2, 'never'], //nr
-		'space-in-parens': [2, 'never'],
-		'space-infix-ops': 2, // nr
+		'@stylistic/semi': 2, // nr
+		'@stylistic/space-before-blocks': [2, 'always'], // nr
+		'@stylistic/space-before-function-paren': [2, 'never'], //nr
+		'@stylistic/space-in-parens': [2, 'never'],
+		'@stylistic/space-infix-ops': 2, // nr
 		'strict': [2, 'global'], // nr
 		'valid-typeof': 2,
 		'@stylistic/indent': [2, 'tab', { 'SwitchCase': 1 }], // nr

--- a/configs/browser.js
+++ b/configs/browser.js
@@ -25,8 +25,8 @@ export default [
 			},
 		},
 		rules: {
-			'arrow-spacing': 2,
-			'no-confusing-arrow': 2,
+			'@stylistic/arrow-spacing': 2,
+			'@stylistic/no-confusing-arrow': 2,
 			'no-duplicate-imports': 2,
 			'no-useless-constructor': 2,
 			'prefer-arrow-callback': 2,

--- a/configs/browser.js
+++ b/configs/browser.js
@@ -25,8 +25,7 @@ export default [
 			},
 		},
 		rules: {
-			'@stylistic/arrow-spacing': 2,
-			'@stylistic/no-confusing-arrow': 2,
+			'no-console': ['error', { 'allow': ['warn', 'error'] }],
 			'no-duplicate-imports': 2,
 			'no-useless-constructor': 2,
 			'prefer-arrow-callback': 2,
@@ -36,7 +35,8 @@ export default [
 			'strict': [2, 'never'],
 			'import/extensions': ['error', 'ignorePackages'],
 			'import/no-absolute-path': 2,
-			'no-console': ['error', { 'allow': ['warn', 'error'] }],
+			'@stylistic/arrow-spacing': 2,
+			'@stylistic/no-confusing-arrow': 2,
 			...getSortMemberRules()
 		}
 	}


### PR DESCRIPTION
This just switches to the non-deprecated version of eslint rules. The only one I was able to trigger on my projects was `@stylistic/space-before-function-paren` this was not being processed before this change since the `space-before-function-paren` didn't seem to work anymore. I expect there will be others that affect downstream consumers.

https://desire2learn.atlassian.net/browse/QE-1995