### PR TITLE
fix: `@stylistic/space-before-function-paren` handling of `catch` blocks

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -43,7 +43,12 @@ export default [js.configs.recommended, {
 		'@stylistic/quotes': [2, 'single', { 'avoidEscape': true }], // nr
 		'@stylistic/semi': 2, // nr
 		'@stylistic/space-before-blocks': [2, 'always'], // nr
-		'@stylistic/space-before-function-paren': [2, 'never'], //nr
+		'@stylistic/space-before-function-paren': [2, {
+			"anonymous": "never",
+			"named": "never",
+			"asyncArrow": "never",
+			"catch": "always"
+		}], //nr
 		'@stylistic/space-in-parens': [2, 'never'],
 		'@stylistic/space-infix-ops': 2 // nr
 	}

--- a/configs/base.js
+++ b/configs/base.js
@@ -44,10 +44,10 @@ export default [js.configs.recommended, {
 		'@stylistic/semi': 2, // nr
 		'@stylistic/space-before-blocks': [2, 'always'], // nr
 		'@stylistic/space-before-function-paren': [2, {
-			"anonymous": "never",
-			"named": "never",
-			"asyncArrow": "never",
-			"catch": "always"
+			'anonymous': 'never',
+			'named': 'never',
+			'asyncArrow': 'never',
+			'catch': 'always'
 		}], //nr
 		'@stylistic/space-in-parens': [2, 'never'],
 		'@stylistic/space-infix-ops': 2 // nr


### PR DESCRIPTION
Minor adjustment to handle changes from `space-before-function-paren` to `@stylistic/space-before-function-paren` this seems to keep the same behaviour we wanted with `space-before-function-paren`

https://desire2learn.atlassian.net/browse/QE-1995